### PR TITLE
removed tomcat-juli/tomcat-jdbc dependency

### DIFF
--- a/Camel/Camel-JMS-JDBC-XA-TX/routing/pom.xml
+++ b/Camel/Camel-JMS-JDBC-XA-TX/routing/pom.xml
@@ -57,24 +57,7 @@
         </dependency>
 
         <!-- JDBC related dependencies -->
-        <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-jdbc</artifactId>
-            <version>${tomcat-jdbc.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-juli</artifactId>
-            <version>${tomcat-jdbc.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>juli</artifactId>
-            <version>${juli.version}</version>
-            <scope>provided</scope>
-        </dependency>
+        
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>


### PR DESCRIPTION
Great examples Torsten.

When I tried to compile Camel-JMS-JDBC-XA-TX I got the following exception

``` java
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project org.apache.camel.demo.camel-jms-jdbc-xa:routing:2.0.0 (/Users/pfox/fuse/_repos/fuse-demos/Camel/Camel-JMS-JDBC-XA-TX/routing/pom.xml) has 3 errors
[ERROR]     'dependencies.dependency.version' for org.apache.tomcat:tomcat-jdbc:jar must be a valid version but is '${tomcat-jdbc.version}'. @ line 63, column 22
[ERROR]     'dependencies.dependency.version' for org.apache.tomcat:tomcat-juli:jar must be a valid version but is '${tomcat-jdbc.version}'. @ line 69, column 22
[ERROR]     'dependencies.dependency.version' for org.apache.tomcat:juli:jar must be a valid version but is '${juli.version}'. @ line 75, column 22
[ERROR]
```

I guess this was left from previous versions as I don´t think tomcat-jdbc/tomcat-juli is required by that demo.

Anyway added a pull request that removes the dependency - seem to resolve the issue for me.

Thanks
Pat
